### PR TITLE
Add sote handler and sote back wall hiding

### DIFF
--- a/src/main/java/com/tobutilities/TobUtilitiesConfig.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesConfig.java
@@ -473,6 +473,23 @@ public interface TobUtilitiesConfig extends Config
 		return new Color(89, 0, 0);
 	}
 
+	@ConfigSection(
+			name = "Sotetseg",
+			description = "Change Sotetseg settings",
+			position = 4
+	)
+	String Sotetseg = "Sotetseg Settings";
 
+	@ConfigItem(
+			keyName = "hideSoteWalls",
+			name = "Hide Sotetseg Walls",
+			description = "Enable hiding back walls at Sotetseg",
+			position = 1,
+			section = Sotetseg
+	)
+	default boolean hideSotetsegWalls()
+	{
+		return false;
+	}
 }
 

--- a/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
@@ -19,6 +19,7 @@ import com.tobutilities.common.player.PlayerFourOrbOverlay;
 import com.tobutilities.common.player.PlayerFiveOrbOverlay;
 import com.tobutilities.nylocas.NylocasHandler;
 import com.tobutilities.nylocas.NylocasOverlay;
+import com.tobutilities.sote.SoteHandler;
 import com.tobutilities.verzik.DawnbringerStatusMessage;
 import com.tobutilities.verzik.LightbearerWarningOverlay;
 import com.tobutilities.verzik.VerzikHandler;
@@ -99,6 +100,9 @@ public class TobUtilitiesPlugin extends Plugin
 	private NylocasHandler nylocasHandler;
 
 	@Inject
+	private SoteHandler soteHandler;
+
+	@Inject
 	private VerzikHandler verzikHandler;
 	@Inject
 	private MetronomeService metronomeService;
@@ -125,6 +129,8 @@ public class TobUtilitiesPlugin extends Plugin
 
 			if (localRegion.equals(Region.BLOAT)) {
 				return bloatHandler.drawObject(scene, object);
+			} else if (localRegion.equals(Region.SOTETSEG)) {
+				return soteHandler.drawObject(scene, object);
 			}
 
 			return RenderCallback.super.drawObject(scene, object);
@@ -162,6 +168,9 @@ public class TobUtilitiesPlugin extends Plugin
 		if (oldRegion.equals(Region.BLOAT) && !region.equals(Region.BLOAT))
 		{
 			bloatHandler.onRoomExit();
+		}
+		if (!oldRegion.equals(Region.SOTETSEG) && region.equals(Region.SOTETSEG)) {
+			soteHandler.onRoomEntry();
 		}
 		if (region.equals(Region.MAIDEN))
 		{
@@ -291,6 +300,7 @@ public class TobUtilitiesPlugin extends Plugin
     public void onConfigChanged(ConfigChanged event)
     {
         bloatHandler.onConfigChanged(event);
+		soteHandler.onConfigChanged(event);
 
 		clientThread.invokeLater(this::tryReloadScene);
 	}
@@ -316,6 +326,7 @@ public class TobUtilitiesPlugin extends Plugin
 		overlayManager.add(lightbearerWarningOverlay);
 		overlayManager.add(nylocasOverlay);
         bloatHandler.startUp();
+		soteHandler.startUp();
 		verzikHandler.startUp();
 		wsClient.registerMessage(DawnbringerStatusMessage.class);
 		keyManager.registerKeyListener(hideVerzikHotkeyListener);

--- a/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
@@ -2,11 +2,13 @@ package com.tobutilities;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
+import com.tobutilities.bloat.BloatConstants;
 import com.tobutilities.bloat.BloatHandler;
 import com.tobutilities.bloat.BloatPlayerOverlay;
 import com.tobutilities.common.metronome.MetronomeService;
 import com.tobutilities.common.metronome.MetronomeOverlay;
 import com.tobutilities.common.enums.Region;
+import com.tobutilities.common.util.CommonUtils;
 import com.tobutilities.maiden.MaidenHandler;
 import com.tobutilities.maiden.ScuffWarningOverlay;
 import com.tobutilities.maiden.ScuffedNylocasOverlay;
@@ -23,9 +25,14 @@ import com.tobutilities.verzik.VerzikHandler;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
 
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.callback.Hooks;
+import net.runelite.client.callback.RenderCallback;
+import net.runelite.client.callback.RenderCallbackManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -98,9 +105,44 @@ public class TobUtilitiesPlugin extends Plugin
 	@Inject
 	private WSClient wsClient;
 
+	@Inject
+	private RenderCallbackManager renderCallbackManager;
+
+	@Inject
+	private ClientThread clientThread;
+
 
 	public Region region = Region.UNKNOWN;
 	private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
+
+	private final RenderCallback renderCallback = new RenderCallback() {
+
+		@Override
+		public boolean drawObject(Scene scene, TileObject object) {
+			// Need to calculate the region in this call instead of using the shared one updated by the metronome because
+			// this will get called before onGameTick, so the region will be incorrect when walking into a new room.
+			Region localRegion = CommonUtils.getRegionByRegionId(CommonUtils.getRegionID(client));
+
+			if (localRegion.equals(Region.BLOAT)) {
+				return bloatHandler.drawObject(scene, object);
+			}
+
+			return RenderCallback.super.drawObject(scene, object);
+		}
+
+		@Override
+		public boolean addEntity(Renderable renderable, boolean drawingUi) {
+			// Need to calculate the region in this call instead of using the shared one updated by the metronome because
+			// this will get called before onGameTick, so the region will be incorrect when walking into a new room.
+			Region localRegion = CommonUtils.getRegionByRegionId(CommonUtils.getRegionID(client));
+
+			if (localRegion.equals(Region.BLOAT)) {
+				return bloatHandler.addEntity(renderable, drawingUi);
+			}
+
+			return RenderCallback.super.addEntity(renderable, drawingUi);
+		}
+	};
 
 	@Provides
 	TobUtilitiesConfig provideConfig(ConfigManager configManager)
@@ -114,6 +156,9 @@ public class TobUtilitiesPlugin extends Plugin
 		Region oldRegion = region;
         // metronomeService updates region
 		metronomeService.onGameTick(tick);
+		if (!oldRegion.equals(Region.BLOAT) && region.equals(Region.BLOAT)) {
+			bloatHandler.onRoomEntry();
+		}
 		if (oldRegion.equals(Region.BLOAT) && !region.equals(Region.BLOAT))
 		{
 			bloatHandler.onRoomExit();
@@ -166,7 +211,6 @@ public class TobUtilitiesPlugin extends Plugin
 		}
 	};
 
-
 	@Subscribe
 	public void onNpcSpawned(NpcSpawned event)
 	{
@@ -184,11 +228,6 @@ public class TobUtilitiesPlugin extends Plugin
 	@VisibleForTesting
 	boolean shouldDraw(Renderable renderable, boolean drawingUI)
 	{
-		if (Region.BLOAT.equals(region))
-		{
-			return bloatHandler.shouldDraw(renderable, drawingUI);
-		}
-
 		if (Region.VERZIK.equals(region))
 		{
 			return verzikHandler.shouldDraw(renderable, drawingUI);
@@ -252,7 +291,9 @@ public class TobUtilitiesPlugin extends Plugin
     public void onConfigChanged(ConfigChanged event)
     {
         bloatHandler.onConfigChanged(event);
-    }
+
+		clientThread.invokeLater(this::tryReloadScene);
+	}
 
     @Subscribe
     public void onGameStateChanged(GameStateChanged event)
@@ -280,6 +321,9 @@ public class TobUtilitiesPlugin extends Plugin
 		keyManager.registerKeyListener(hideVerzikHotkeyListener);
 		keyManager.registerKeyListener(metronomeResetHotkeyListener);
 		hooks.registerRenderableDrawListener(drawListener);
+		renderCallbackManager.register(renderCallback);
+
+		clientThread.invokeLater(this::tryReloadScene);
 	}
 
 	@Override
@@ -304,5 +348,14 @@ public class TobUtilitiesPlugin extends Plugin
 		keyManager.unregisterKeyListener(hideVerzikHotkeyListener);
 		keyManager.unregisterKeyListener(metronomeResetHotkeyListener);
 		hooks.unregisterRenderableDrawListener(drawListener);
+		renderCallbackManager.unregister(renderCallback);
+
+		clientThread.invokeLater(this::tryReloadScene);
+	}
+
+	private void tryReloadScene() {
+		assert client.isClientThread();
+		if (client.getGameState() == GameState.LOGGED_IN)
+			client.setGameState(GameState.LOADING);
 	}
 }

--- a/src/main/java/com/tobutilities/bloat/BloatHandler.java
+++ b/src/main/java/com/tobutilities/bloat/BloatHandler.java
@@ -8,26 +8,29 @@ import com.tobutilities.TobUtilitiesConfig;
 import javax.inject.Inject;
 
 import com.tobutilities.common.enums.Region;
+import com.tobutilities.common.util.CommonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 
+import net.runelite.client.callback.RenderCallback;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
-public class BloatHandler extends RoomHandler
+public class BloatHandler extends RoomHandler implements RenderCallback
 {
 	private boolean isBloatAlive = false;
-    private final Map<LocalPoint, GroundObject> hiddenObjects = new HashMap<>();
     private int bloatSkyboxColor;
     private boolean bloatSkyboxOverride;
     private boolean hideBloatFloor;
@@ -44,7 +47,22 @@ public class BloatHandler extends RoomHandler
 		super(plugin, config, client);
 	}
 
-	public boolean shouldDraw(Renderable renderable, boolean drawingUi)
+    @Override
+    public boolean drawObject(Scene scene, TileObject object)
+    {
+        if (!(object instanceof GroundObject)) {
+            return RenderCallback.super.drawObject(scene, object);
+        }
+        GroundObject groundObject = (GroundObject) object;
+        if (hideBloatFloor && BloatConstants.BLOAT_FLOOR_IDS.contains(groundObject.getId())) {
+            return false;
+        }
+
+        return RenderCallback.super.drawObject(scene, object);
+    }
+
+    @Override
+    public boolean addEntity(Renderable renderable, boolean drawingUi)
 	{
 		if (renderable instanceof Player && isBloatAlive)
 		{
@@ -61,7 +79,7 @@ public class BloatHandler extends RoomHandler
 				return !config.hideOtherPlayersDuringBloat();
 			}
 		}
-		return true;
+		return RenderCallback.super.addEntity(renderable, drawingUi);
 	}
 
 	@Subscribe
@@ -76,7 +94,6 @@ public class BloatHandler extends RoomHandler
 			}
 		}
         updateHdConfig();
-        updateGroundObjects();
 	}
 
     @Subscribe
@@ -85,19 +102,16 @@ public class BloatHandler extends RoomHandler
         switch (event.getGameState())
         {
             case LOADING:
-                hiddenObjects.clear();
                 break;
 
             case LOGGED_IN:
                 if (plugin.region == Region.BLOAT)
                 {
-                    updateGroundObjects();
                     updateHdConfig();
                 }
                 break;
 
             case LOGIN_SCREEN:
-                hiddenObjects.clear();
                 restoreHdConfig();
                 break;
         }
@@ -121,7 +135,7 @@ public class BloatHandler extends RoomHandler
             {
                 case "hideBloatFloor":
                     hideBloatFloor = config.hideBloatFloor();
-                    updateGroundObjects();
+                    onRoomEntry();
                     break;
 
                 case "bloatSkyboxOverride":
@@ -134,105 +148,6 @@ public class BloatHandler extends RoomHandler
                     break;
             }
         }
-    }
-
-    private void updateGroundObjects()
-    {
-        if (hideBloatFloor)
-        {
-            hideGroundObjects();
-        }
-        else
-        {
-            unhideGroundObjects();
-        }
-    }
-
-    private void hideGroundObjects()
-    {
-        Scene scene = client.getTopLevelWorldView().getScene();
-
-        if (scene == null)
-        {
-            return;
-        }
-
-        Tile[][][] tiles = scene.getTiles();
-
-        for (int z = 0; z < Constants.MAX_Z; z++)
-        {
-            if (tiles[z] == null) continue;
-
-            for (int x = 0; x < Constants.SCENE_SIZE; x++)
-            {
-                if (tiles[z][x] == null) continue;
-
-                for (int y = 0; y < Constants.SCENE_SIZE; y++)
-                {
-                    Tile tile = tiles[z][x][y];
-                    if (tile == null)
-                    {
-                        continue;
-                    }
-
-                    GroundObject groundObject = tile.getGroundObject();
-                    if (groundObject != null && BLOAT_FLOOR_IDS.contains(groundObject.getId()))
-                    {
-                        LocalPoint lp = tile.getLocalLocation();
-
-                        // Skip if already hidden
-                        if (hiddenObjects.containsKey(lp)) continue;
-
-                        // Cache original object
-                        hiddenObjects.put(lp, groundObject);
-
-                        // Remove it from the scene
-                        tile.setGroundObject(null);
-                    }
-                }
-            }
-        }
-    }
-
-    private void unhideGroundObjects()
-    {
-        Scene scene = client.getTopLevelWorldView().getScene();
-        if (scene == null)
-        {
-            hiddenObjects.clear();
-            return;
-        }
-
-        for (Map.Entry<LocalPoint, GroundObject> entry : hiddenObjects.entrySet())
-        {
-            LocalPoint lp = entry.getKey();
-            Tile tile = getTileAtLocalPoint(lp);
-            if (tile == null)
-                continue;
-
-            // Restore ground object if not already present
-            if (tile.getGroundObject() == null)
-            {
-                tile.setGroundObject(entry.getValue());
-            }
-        }
-        hiddenObjects.clear();
-    }
-
-    private Tile getTileAtLocalPoint(LocalPoint point)
-    {
-        WorldView wv = client.getTopLevelWorldView();
-        Scene scene = wv.getScene();
-        Tile[][] tiles = scene.getTiles()[wv.getPlane()];
-        int sceneX = point.getSceneX();
-        int sceneY = point.getSceneY();
-
-        if (sceneX < 0 || sceneY < 0 || sceneX >= Constants.SCENE_SIZE || sceneY >= Constants.SCENE_SIZE)
-        {
-            return null;
-        }
-
-        return tiles[sceneX][sceneY];
     }
 
     private void updateHdConfig() {
@@ -287,7 +202,19 @@ public class BloatHandler extends RoomHandler
     public void onRoomExit()
     {
         restoreHdConfig();
-        unhideGroundObjects();
+    }
+
+    public void onRoomEntry() {
+        if (hideBloatFloor) {
+            CommonUtils.checkForLegacyGPUAndPrintWarning(
+                    clientThread,
+                    pluginManager,
+                    client,
+                    "Bloat floor hiding does not work with legacy GPU; " +
+                            "either switch to the updated GPU plugin, or disable floor hiding " +
+                            "in the bloat options in ToB Utilities."
+            );
+        }
     }
 
     public void startUp()
@@ -297,7 +224,6 @@ public class BloatHandler extends RoomHandler
         bloatSkyboxOverride = config.enableBloatSkyboxOverride();
         if (client.getGameState() == GameState.LOGGED_IN)
         {
-            updateGroundObjects();
             updateHdConfig();
         }
     }

--- a/src/main/java/com/tobutilities/common/RoomHandler.java
+++ b/src/main/java/com/tobutilities/common/RoomHandler.java
@@ -5,7 +5,9 @@ import com.tobutilities.TobUtilitiesConfig;
 import com.tobutilities.TobUtilitiesPlugin;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 public class RoomHandler
@@ -13,9 +15,14 @@ public class RoomHandler
 	@Inject
 	protected Client client;
 	@Inject
+	protected PluginManager pluginManager;
+	@Inject
 	private OverlayManager overlayManager;
 	@Inject
 	private ConfigManager configManager;
+
+	@Inject
+	protected ClientThread clientThread;
 
 	protected TobUtilitiesConfig config;
 

--- a/src/main/java/com/tobutilities/common/metronome/MetronomeService.java
+++ b/src/main/java/com/tobutilities/common/metronome/MetronomeService.java
@@ -9,6 +9,8 @@ import java.awt.event.KeyEvent;
 import java.util.Random;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import com.tobutilities.common.util.CommonUtils;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -57,11 +59,7 @@ public class MetronomeService
 	public void onGameTick(GameTick tick)
 	{
 		int regionTickCount;
-		Player player = client.getLocalPlayer();
-		final LocalPoint playerLocation = player.getLocalLocation();
-		WorldPoint playerLocationPoint = WorldPoint.fromLocalInstance(client, playerLocation);
-		final int regionId = playerLocationPoint.getRegionID();
-		Region newTickRegion = getRegionByRegionId(regionId);
+		Region newTickRegion = CommonUtils.getRegionByRegionId(CommonUtils.getRegionID(client));
 
 		if (newTickRegion != plugin.region)
 		{

--- a/src/main/java/com/tobutilities/common/util/CommonUtils.java
+++ b/src/main/java/com/tobutilities/common/util/CommonUtils.java
@@ -1,6 +1,14 @@
 package com.tobutilities.common.util;
 
 import com.tobutilities.common.enums.Region;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginManager;
 
 public class CommonUtils
 {
@@ -24,6 +32,21 @@ public class CommonUtils
 				return Region.VERZIK;
 			default:
 				return Region.UNKNOWN;
+		}
+	}
+
+	public static int getRegionID(Client client) {
+		Player player = client.getLocalPlayer();
+		final LocalPoint playerLocation = player.getLocalLocation();
+		WorldPoint playerLocationPoint = WorldPoint.fromLocalInstance(client, playerLocation);
+		return playerLocationPoint.getRegionID();
+	}
+
+	public static void checkForLegacyGPUAndPrintWarning(ClientThread clientThread, PluginManager pluginManager, Client client, String message) {
+		for (Plugin plugin : pluginManager.getPlugins()) {
+			if (plugin.getName().equals("GPU (legacy)") && pluginManager.isPluginActive(plugin)) {
+				clientThread.invoke(() -> client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", message, ""));
+			}
 		}
 	}
 }

--- a/src/main/java/com/tobutilities/sote/SoteConstants.java
+++ b/src/main/java/com/tobutilities/sote/SoteConstants.java
@@ -1,0 +1,23 @@
+package com.tobutilities.sote;
+
+import java.util.List;
+
+public class SoteConstants {
+    public static final List<Integer> SOTE_WALL_IDS = List.of(
+            33044,
+            33046,
+            33047,
+            33048,
+            33049,
+            33050,
+            33051,
+            33052,
+            33053,
+            33054,
+            33055,
+            33056,
+            33057,
+            33058,
+            33059
+    );
+}

--- a/src/main/java/com/tobutilities/sote/SoteHandler.java
+++ b/src/main/java/com/tobutilities/sote/SoteHandler.java
@@ -1,0 +1,69 @@
+package com.tobutilities.sote;
+
+import com.tobutilities.TobUtilitiesConfig;
+import com.tobutilities.TobUtilitiesPlugin;
+import com.tobutilities.bloat.BloatConstants;
+import com.tobutilities.common.RoomHandler;
+import com.tobutilities.common.util.CommonUtils;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
+import net.runelite.client.callback.RenderCallback;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+
+import javax.inject.Inject;
+
+@Slf4j
+public class SoteHandler extends RoomHandler implements RenderCallback {
+    private boolean hideSotetsegWalls;
+
+    @Inject
+    protected SoteHandler(TobUtilitiesPlugin plugin, TobUtilitiesConfig config, Client client)
+    {
+        super(plugin, config, client);
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (event.getGroup().equals("tobutilities")) {
+            switch (event.getKey()) {
+                case "hideSoteWalls":
+                    hideSotetsegWalls = config.hideSotetsegWalls();
+                    onRoomEntry();
+            }
+        }
+    }
+
+    @Override
+    public boolean drawObject(Scene scene, TileObject object)
+    {
+        if (!(object instanceof GameObject)) {
+            return RenderCallback.super.drawObject(scene, object);
+        }
+        GameObject gameObject = (GameObject) object;
+        if (hideSotetsegWalls && SoteConstants.SOTE_WALL_IDS.contains(gameObject.getId())) {
+            return false;
+        }
+
+        return RenderCallback.super.drawObject(scene, object);
+    }
+
+    public void onRoomEntry()
+    {
+        if (hideSotetsegWalls) {
+            CommonUtils.checkForLegacyGPUAndPrintWarning(
+                    clientThread,
+                    pluginManager,
+                    client,
+                    "Sotetseg wall hiding does not work with legacy GPU; " +
+                            "either switch to the updated GPU plugin, or disable wall hiding " +
+                            "in the bloat options in ToB Utilities."
+            );
+        }
+    }
+
+    public void startUp()
+    {
+        hideSotetsegWalls = config.hideSotetsegWalls();
+    }
+}


### PR DESCRIPTION
Add a config setting to remove the back wall at sotesteg, equivalent to how https://github.com/Need-Femboy/SoteWallRemover works but updated for the new GPU plugin. This relies on the logging functionality added in https://github.com/NCG-RS/TobUtilities/pull/13 to log a game message when the legacy gpu plugin is enabled with this option. 

It would probably make sense to rewrite `onGameTick` in `TobUtilitiesPlugin` to have some generalized understanding of room entry/exit instead of the if-chain, but didn't add that here; I can refactor it in a separate PR if interested.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/NCG-RS/TobUtilities/pull/14).
* __->__ #14
* #13