### PR TITLE
Refactor Bloat floor handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The primary goal of this plugin is to minimize the need for mid-raid configurati
 
 ### Bloat
 - The ability to hide self or other players while in bloat room
-- The ability to hide the floor in bloat room with a skybox override (Works with GPU/117)
+- The ability to hide the ground objects in bloat room and adjust the color of the floor
 
 ### Nylocas
 - Aggressive highlighting

--- a/src/main/java/com/tobutilities/TobUtilitiesConfig.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesConfig.java
@@ -315,39 +315,26 @@ public interface TobUtilitiesConfig extends Config
 	}
 
     @ConfigItem(
-            keyName = "hideBloatFloor",
-            name = "Hide floor",
+            keyName = "hideBloatGroundObjects",
+            name = "Hide ground objects",
             description = "Enable hiding ground objects in the bloat room",
             position = 4,
             section = Bloat
     )
-    default boolean hideBloatFloor()
+    default boolean hideBloatGroundObjects()
     {
         return false;
     }
 
     @ConfigItem(
-            keyName = "bloatSkyboxOverride",
-            name = "Skybox override",
-            description = "Override the skybox color in the bloat room",
-            position = 5,
-            section = Bloat
-    )
-
-    default boolean enableBloatSkyboxOverride()
-    {
-        return false;
-    }
-
-    @ConfigItem(
-            keyName = "bloatSkyboxColor",
-            name = "Skybox color",
-            description = "The color for the skybox in the bloat room",
+            keyName = "bloatFloorColor",
+            name = "Floor color",
+            description = "The color for the floor in the bloat room",
             position = 6,
             section = Bloat
     )
 
-    default Color bloatSkyboxColor()
+    default Color bloatFloorColor()
     {
 		return new Color(178,150,203);
     }

--- a/src/main/java/com/tobutilities/TobUtilitiesConfig.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesConfig.java
@@ -315,13 +315,13 @@ public interface TobUtilitiesConfig extends Config
 	}
 
     @ConfigItem(
-            keyName = "hideBloatGroundObjects",
-            name = "Hide ground objects",
+            keyName = "hideBloatFloor",
+            name = "Hide floor",
             description = "Enable hiding ground objects in the bloat room",
             position = 4,
             section = Bloat
     )
-    default boolean hideBloatGroundObjects()
+    default boolean hideBloatFloor()
     {
         return false;
     }

--- a/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
@@ -293,8 +293,6 @@ public class TobUtilitiesPlugin extends Plugin
     public void onConfigChanged(ConfigChanged event)
     {
         bloatHandler.onConfigChanged(event);
-
-		clientThread.invokeLater(this::tryReloadScene);
 	}
 
     @Subscribe

--- a/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
+++ b/src/main/java/com/tobutilities/TobUtilitiesPlugin.java
@@ -46,6 +46,7 @@ import net.runelite.client.util.HotkeyListener;
 
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
+import java.util.Arrays;
 
 @PluginDescriptor(
 	name = "ToB Utilities",
@@ -116,19 +117,6 @@ public class TobUtilitiesPlugin extends Plugin
 	private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
 
 	private final RenderCallback renderCallback = new RenderCallback() {
-
-		@Override
-		public boolean drawObject(Scene scene, TileObject object) {
-			// Need to calculate the region in this call instead of using the shared one updated by the metronome because
-			// this will get called before onGameTick, so the region will be incorrect when walking into a new room.
-			Region localRegion = CommonUtils.getRegionByRegionId(CommonUtils.getRegionID(client));
-
-			if (localRegion.equals(Region.BLOAT)) {
-				return bloatHandler.drawObject(scene, object);
-			}
-
-			return RenderCallback.super.drawObject(scene, object);
-		}
 
 		@Override
 		public boolean addEntity(Renderable renderable, boolean drawingUi) {
@@ -281,25 +269,22 @@ public class TobUtilitiesPlugin extends Plugin
 		}
 	}
 
-    @Subscribe (priority = -1.0f)
-    public void onBeforeRender(BeforeRender r)
-    {
-        if (region.equals(Region.BLOAT)) {
-            bloatHandler.onBeforeRender(r);
-        }
-    }
-
     @Subscribe
     public void onConfigChanged(ConfigChanged event)
     {
-        bloatHandler.onConfigChanged(event);
+		if (Region.BLOAT.equals(region)) {
+			bloatHandler.onConfigChanged(event);
+		}
 	}
 
-    @Subscribe
-    public void onGameStateChanged(GameStateChanged event)
-    {
-        bloatHandler.onGameStateChanged(event);
-    }
+	@Subscribe
+	public void onPreMapLoad(PreMapLoad event)
+	{
+		if (Arrays.stream(event.getScene().getMapRegions())
+				.anyMatch(id -> id == Region.BLOAT.getRegionId())) {
+			bloatHandler.onPreMapLoad(event);
+		}
+	}
 
 	@Override
 	protected void startUp() throws Exception

--- a/src/main/java/com/tobutilities/bloat/BloatHandler.java
+++ b/src/main/java/com/tobutilities/bloat/BloatHandler.java
@@ -24,6 +24,7 @@ import java.awt.*;
 @Slf4j
 public class BloatHandler extends RoomHandler implements RenderCallback
 {
+	private static final String configGroup = "tobutilities";
 	private boolean isBloatAlive = false;
 
     // Bloat floor coordinates
@@ -189,7 +190,7 @@ public class BloatHandler extends RoomHandler implements RenderCallback
     @Subscribe
     public void onConfigChanged(ConfigChanged event)
     {
-        if ("tobutilities".equals(event.getGroup()))
+        if (configGroup.equals(event.getGroup()))
         {
             switch (event.getKey())
             {
@@ -216,7 +217,17 @@ public class BloatHandler extends RoomHandler implements RenderCallback
 
     public void onRoomEntry() {}
 
-    public void startUp() {}
+	public void startUp()
+	{
+		// Migrate old skybox color config to new floor color config
+		String oldSkyboxColor = configManager.getConfiguration(configGroup, "bloatSkyboxColor");
+		if (oldSkyboxColor != null)
+		{
+			log.debug("Migrating Bloat floor color config");
+			configManager.setConfiguration(configGroup, "bloatFloorColor", oldSkyboxColor);
+			configManager.unsetConfiguration(configGroup, "bloatSkyboxColor");
+		}
+	}
 
     public void shutDown() {}
 }

--- a/src/main/java/com/tobutilities/bloat/BloatHandler.java
+++ b/src/main/java/com/tobutilities/bloat/BloatHandler.java
@@ -7,36 +7,37 @@ import com.tobutilities.TobUtilitiesPlugin;
 import com.tobutilities.TobUtilitiesConfig;
 import javax.inject.Inject;
 
-import com.tobutilities.common.enums.Region;
-import com.tobutilities.common.util.CommonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import net.runelite.api.*;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.BeforeRender;
-import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 
+import net.runelite.api.events.PreMapLoad;
 import net.runelite.client.callback.RenderCallback;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.plugins.Plugin;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.awt.*;
 
 @Slf4j
 public class BloatHandler extends RoomHandler implements RenderCallback
 {
 	private boolean isBloatAlive = false;
-    private int bloatSkyboxColor;
-    private boolean bloatSkyboxOverride;
-    private boolean hideBloatFloor;
-    private String originalHdSkyColorConfig;
-    private String originalHdSkyConfig;
-    private boolean hdConfigApplied;
+
+    // Bloat floor coordinates
+    private static final int MIN_X = 3288;
+    private static final int MAX_X = 3303;
+    private static final int MIN_Y = 4440;
+    private static final int MAX_Y = 4455;
+    private static final int PLANE = 0;
+
+    // Inner square (Chamber object) to skip
+    private static final int INNER_MIN_X = 3293;
+    private static final int INNER_MAX_X = 3298;
+    private static final int INNER_MIN_Y = 4445;
+    private static final int INNER_MAX_Y = 4450;
 
     @Inject
     private ConfigManager configManager;
@@ -46,20 +47,6 @@ public class BloatHandler extends RoomHandler implements RenderCallback
 	{
 		super(plugin, config, client);
 	}
-
-    @Override
-    public boolean drawObject(Scene scene, TileObject object)
-    {
-        if (!(object instanceof GroundObject)) {
-            return RenderCallback.super.drawObject(scene, object);
-        }
-        GroundObject groundObject = (GroundObject) object;
-        if (hideBloatFloor && BloatConstants.BLOAT_FLOOR_IDS.contains(groundObject.getId())) {
-            return false;
-        }
-
-        return RenderCallback.super.drawObject(scene, object);
-    }
 
     @Override
     public boolean addEntity(Renderable renderable, boolean drawingUi)
@@ -82,6 +69,110 @@ public class BloatHandler extends RoomHandler implements RenderCallback
 		return RenderCallback.super.addEntity(renderable, drawingUi);
 	}
 
+    private void hideBloatGroundObject(Tile tile)
+    {
+        if (tile == null)
+        {
+            return;
+        }
+
+        GroundObject obj = tile.getGroundObject();
+        if (obj != null && BLOAT_FLOOR_IDS.contains(obj.getId()))
+        {
+            tile.setGroundObject(null);
+        }
+    }
+
+    @Subscribe public void onPreMapLoad(PreMapLoad event)
+    {
+        if (!config.hideBloatGroundObjects())
+        {
+            return;
+        }
+
+        int hsl = getSafeHsl(config.bloatFloorColor());
+
+        Scene scene = event.getScene();
+        Tile[][][] tiles = scene.getTiles();
+        Tile[][] planeTiles = tiles[0];
+        for (Tile[] row : planeTiles) {
+            for (Tile tile : row) {
+                if (!isBloatFloor(scene, tile))
+                {
+                    continue;
+                }
+                recolorTile(tile, hsl);
+                hideBloatGroundObject(tile);
+            }
+        }
+    }
+
+    private boolean isBloatFloor(Scene scene, Tile tile)
+    {
+        if (tile == null || tile.getPlane() != PLANE)
+        {
+            return false;
+        }
+
+        WorldPoint wp = WorldPoint.fromLocalInstance(scene, tile.getLocalLocation(), tile.getPlane());
+
+        // Check outer bounds
+        boolean inOuter = wp.getX() >= MIN_X && wp.getX() <= MAX_X
+                && wp.getY() >= MIN_Y && wp.getY() <= MAX_Y;
+
+        // Check inner bounds (tiles below the Chamber object in the middle of the room)
+        boolean inInner = wp.getX() >= INNER_MIN_X && wp.getX() <= INNER_MAX_X
+                && wp.getY() >= INNER_MIN_Y && wp.getY() <= INNER_MAX_Y;
+
+        return inOuter && !inInner;
+    }
+
+    private void recolorTile(Tile tile, int color)
+    {
+        SceneTilePaint paint = tile.getSceneTilePaint();
+        if (paint != null)
+        {
+            paint.setNwColor(color);
+            paint.setNeColor(color);
+            paint.setSwColor(color);
+            paint.setSeColor(color);
+            tile.setSceneTilePaint(paint);
+        }
+    }
+
+    // Some RGB colors (blue/magenta) will not render properly when converting to HSL which is why I add a small offset to light.
+    // The color will be slightly lighter but this ensures it will render.
+    private int getSafeHsl(Color color)
+    {
+        int r = color.getRed();
+        int g = color.getGreen();
+        int b = color.getBlue();
+        int rgb = (r << 16) | (g << 8) | b;
+
+        int hsl = JagexColor.rgbToHSL(rgb, 1.0);
+        if (hsl > 0)
+        {
+            return hsl;
+        }
+
+        int hue = (hsl >> 10) & 0x3F;
+        int sat = (hsl >> 7) & 0x07;
+        int light = hsl & 0x7F;
+
+        // Add small offset to light
+        light = Math.max(1, light);
+
+        hsl = (hue << 10) | (sat << 7) | light;
+
+        // Fallback to a gray 0x707070
+        if (hsl <= 0)
+        {
+            hsl = JagexColor.rgbToHSL(0x707070, 1.0d);
+        }
+
+        return hsl;
+    }
+
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
@@ -93,149 +184,39 @@ public class BloatHandler extends RoomHandler implements RenderCallback
                 break;
 			}
 		}
-        updateHdConfig();
 	}
-
-    @Subscribe
-    public void onGameStateChanged(GameStateChanged event)
-    {
-        switch (event.getGameState())
-        {
-            case LOADING:
-                break;
-
-            case LOGGED_IN:
-                if (plugin.region == Region.BLOAT)
-                {
-                    updateHdConfig();
-                }
-                break;
-
-            case LOGIN_SCREEN:
-                restoreHdConfig();
-                break;
-        }
-    }
-
-    @Subscribe(priority = -1.0f)
-    public void onBeforeRender(BeforeRender r)
-    {
-        if (bloatSkyboxOverride && client.getGameState() == GameState.LOGGED_IN)
-        {
-            client.setSkyboxColor(bloatSkyboxColor);
-        }
-    }
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event)
     {
-        if (event.getGroup().equals("tobutilities"))
+        if ("tobutilities".equals(event.getGroup()))
         {
             switch (event.getKey())
             {
-                case "hideBloatFloor":
-                    hideBloatFloor = config.hideBloatFloor();
-                    clientThread.invokeLater(() -> {
-                        if (client.getGameState() == GameState.LOGGED_IN)
-                        {
-                            client.setGameState(GameState.LOADING);
-                        }
-                    });
-                    onRoomEntry();
-                    break;
-
-                case "bloatSkyboxOverride":
-                    bloatSkyboxOverride = config.enableBloatSkyboxOverride();
-                    updateHdConfig();
-                    break;
-
-                case "bloatSkyboxColor":
-                    bloatSkyboxColor = config.bloatSkyboxColor().getRGB();
+                case "hideBloatGroundObjects":
+                case "bloatFloorColor":
+                    reloadScene();
                     break;
             }
         }
     }
 
-    private void updateHdConfig() {
-        if (bloatSkyboxOverride && !hdConfigApplied)
-        {
-            overrideHdConfig();
-        }
-        else if (!bloatSkyboxOverride && hdConfigApplied)
-        {
-            restoreHdConfig();
-        }
-    }
-
-    private void overrideHdConfig() {
-        final String group = "hd";
-        // Save original hd config
-        if (originalHdSkyColorConfig == null)
-        {
-            originalHdSkyColorConfig = configManager.getConfiguration(group, "defaultSkyColor");
-        }
-        if (originalHdSkyConfig == null)
-        {
-            originalHdSkyConfig = configManager.getConfiguration(group, "overrideSky");
-        }
-
-        // Apply temporary overrides
-        configManager.setConfiguration(group, "defaultSkyColor", "RUNELITE");
-        configManager.setConfiguration(group, "overrideSky", "true");
-
-        hdConfigApplied = true;
-        log.debug("Applied 117 HD config overrides for Bloat");
-    }
-
-    private void restoreHdConfig() {
-        final String group = "hd";
-        // Restore original hd config
-        if (originalHdSkyColorConfig != null)
-        {
-            configManager.setConfiguration(group, "defaultSkyColor", originalHdSkyColorConfig);
-        }
-        if (originalHdSkyConfig != null)
-        {
-            configManager.setConfiguration(group, "overrideSky", originalHdSkyConfig);
-        }
-
-        hdConfigApplied = false;
-        originalHdSkyColorConfig = null;
-        originalHdSkyConfig = null;
-        log.debug("Restored original 117 HD config");
-    }
-
-    public void onRoomExit()
+    private void reloadScene()
     {
-        restoreHdConfig();
-    }
-
-    public void onRoomEntry() {
-        if (hideBloatFloor) {
-            CommonUtils.checkForLegacyGPUAndPrintWarning(
-                    clientThread,
-                    pluginManager,
-                    client,
-                    "Bloat floor hiding does not work with legacy GPU; " +
-                            "either switch to the updated GPU plugin, or disable floor hiding " +
-                            "in the bloat options in ToB Utilities."
-            );
-        }
-    }
-
-    public void startUp()
-    {
-        hideBloatFloor = config.hideBloatFloor();
-        bloatSkyboxColor = config.bloatSkyboxColor().getRGB();
-        bloatSkyboxOverride = config.enableBloatSkyboxOverride();
-        if (client.getGameState() == GameState.LOGGED_IN)
+        clientThread.invokeLater(() ->
         {
-            updateHdConfig();
-        }
+            if (client.getGameState() == GameState.LOGGED_IN)
+            {
+                client.setGameState(GameState.LOADING);
+            }
+        });
     }
 
-    public void shutDown()
-    {
-        onRoomExit();
-    }
+    public void onRoomExit() {}
+
+    public void onRoomEntry() {}
+
+    public void startUp() {}
+
+    public void shutDown() {}
 }

--- a/src/main/java/com/tobutilities/bloat/BloatHandler.java
+++ b/src/main/java/com/tobutilities/bloat/BloatHandler.java
@@ -85,7 +85,7 @@ public class BloatHandler extends RoomHandler implements RenderCallback
 
     @Subscribe public void onPreMapLoad(PreMapLoad event)
     {
-        if (!config.hideBloatGroundObjects())
+        if (!config.hideBloatFloor())
         {
             return;
         }
@@ -193,7 +193,7 @@ public class BloatHandler extends RoomHandler implements RenderCallback
         {
             switch (event.getKey())
             {
-                case "hideBloatGroundObjects":
+                case "hideBloatFloor":
                 case "bloatFloorColor":
                     reloadScene();
                     break;

--- a/src/main/java/com/tobutilities/bloat/BloatHandler.java
+++ b/src/main/java/com/tobutilities/bloat/BloatHandler.java
@@ -135,6 +135,12 @@ public class BloatHandler extends RoomHandler implements RenderCallback
             {
                 case "hideBloatFloor":
                     hideBloatFloor = config.hideBloatFloor();
+                    clientThread.invokeLater(() -> {
+                        if (client.getGameState() == GameState.LOGGED_IN)
+                        {
+                            client.setGameState(GameState.LOADING);
+                        }
+                    });
                     onRoomEntry();
                     break;
 


### PR DESCRIPTION
This PR refactors how the Bloat floor is handled in the plugin:

- Moved Bloat ground object hiding to onPreMapLoad instead of drawObject, ensuring it works with or without all GPU plugins.
- Replaced the Bloat Skybox "floor recolor" with a proper tile recolor using SceneTilePaint. This also works with or without all GPU plugins and eliminates the need to save/restore the 117 HD config.